### PR TITLE
Update Docker image handling in CI workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,7 +8,7 @@ on:
 env:
   DOTNET_VERSION: '8.0.x'
   AZURE_WEBAPP_NAME: 'fiap-cloud-games'
-  DOCKER_IMAGE_NAME: 'fiap-cloud-games'
+  DOCKER_IMAGE_NAME: '${{ secrets.DOCKER_USERNAME }}/fiap-cloud-games'
 
 jobs:
   build-and-deploy:
@@ -31,16 +31,16 @@ jobs:
         dotnet build --configuration Release --no-restore
         dotnet publish -c Release -o ./publish --no-build
 
-    - name: Build Docker image
-      run: |
-        docker build -t ${{ env.DOCKER_IMAGE_NAME }}:latest .
-        docker tag ${{ env.DOCKER_IMAGE_NAME }}:latest ${{ env.DOCKER_IMAGE_NAME }}:${{ github.sha }}
-
     - name: Login to Docker Hub
       uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Build Docker image
+      run: |
+        docker build -t ${{ env.DOCKER_IMAGE_NAME }}:latest .
+        docker tag ${{ env.DOCKER_IMAGE_NAME }}:latest ${{ env.DOCKER_IMAGE_NAME }}:${{ github.sha }}
 
     - name: Push Docker image
       run: |


### PR DESCRIPTION
- Changed `DOCKER_IMAGE_NAME` to use a secret for the Docker username.
- Added a step to push the Docker image to the repository after building, including both `latest` and SHA-based tags.